### PR TITLE
fix: encode package in deps check

### DIFF
--- a/src/cve/utils/vulnerable_dependency_checker.py
+++ b/src/cve/utils/vulnerable_dependency_checker.py
@@ -346,7 +346,9 @@ class VulnerableDependencyChecker(IntelClient):
         if system not in DEPDEV_SUPPORTED_SYS:
             return self_package
 
-        api_url = (f"v3/systems/{system}/packages/{package}/versions/{version}:dependencies")
+        encoded_pkg = urllib.parse.quote(package, 'utf-8')
+        encoded_ver = urllib.parse.quote(version, 'utf-8')
+        api_url = (f"v3/systems/{system}/packages/{encoded_pkg}/versions/{encoded_ver}:dependencies")
         url = url_join(self.base_url, api_url)
         package_info = {"package": package, "system": system, "version": version}
 


### PR DESCRIPTION
Composed package names including namespaces are not properly encoded to the deps.dev url
e.g. `gorm.io/datatypes` should be encoded like:
`https://api.deps.dev/v3/systems/go/packages/gorm.io%2Fdatatypes/versions/v1.0.5:dependencies`

Backport of https://github.com/nv-morpheus/agent-morpheus-RH/pull/22