### PR TITLE
feat: log input file only for non http requests

### DIFF
--- a/src/cve/pipeline/input.py
+++ b/src/cve/pipeline/input.py
@@ -309,5 +309,17 @@ def build_input(pipe: LinearPipeline, config: Config, run_config: RunConfig):
 
     pipe.add_stage(check_vulnerable_dependencies(config))
 
+    if run_config.input.type != 'http':
+        @stage
+        def debug_input(message: AgentMorpheusEngineInput) -> AgentMorpheusEngineInput:
+
+            # Save the input object to disk for debugging
+            with open("./.tmp/input_object.json", "w") as f:
+                f.write(message.model_dump_json(indent=2))
+
+            return message
+
+        pipe.add_stage(debug_input(config))
+
     # Return embedding model to be used later in the pipeline
     return embedding


### PR DESCRIPTION
There is no need to persist the request when the input type is HTTP as it is already being logged.

This requires that the container has write access to that .tmp folder