### PR TITLE
Exclude manual SBOM info from markdown report

### DIFF
--- a/src/cve/utils/output_formatter.py
+++ b/src/cve/utils/output_formatter.py
@@ -81,7 +81,9 @@ def _add_header(markdown_content, cve_id, model_dict: AgentMorpheusOutput):
     markdown_content.append(
         f"> **Container Analyzed:** `{input_image.name} : {input_image.tag}`\n\n"
     )
-    markdown_content.append(f"> **SBOM Info:** `{input_image.sbom_info}`")
+    # Only add SBOM info if it is a file location
+    if input_image.sbom_info.type == "file":
+        markdown_content.append(f"> **SBOM Info:** `{input_image.sbom_info}`")
 
 
 def _add_table_of_contents(markdown_content, model_dict: AgentMorpheusOutput):


### PR DESCRIPTION
Currently the markdown report includes the full SBOM info, which is very long when the type is `ManualSBOMInfoInput`. This change makes it so that only file type SBOM info will be included in the report.