### PR TITLE
Update `mamba env update` command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ SHELL ["/bin/bash", "-c"]
 RUN --mount=type=cache,id=pip_cache,target=/root/.cache/pip,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate morpheus-vuln-analysis &&\
-    mamba env update morpheus-vuln-analysis -f ./requirements.yaml
+    mamba env update -f ./requirements.yaml
 
 # If any changes have been made from the base image, recopy the sources
 COPY . /workspace/


### PR DESCRIPTION
Container build recently started pulling a new `mamba` release that doesn't accept target environment in `mamba env update` command. This was causing error in the build. Updated the command in the `Dockerfile`.