### PR TITLE
Fix `docker volume rm` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,10 +829,10 @@ If you want to reset just the LLM cache or the services cache, you can run the f
 docker compose down
 
 # To remove the LLM cache
-docker volume rm ${COMPOSE_PROJECT_NAME:-morpheus_vuln_analysis}-llm-cache
+docker volume rm ${COMPOSE_PROJECT_NAME:-morpheus_vuln_analysis}_llm-cache
 
 # To remove the services cache
-docker volume rm ${COMPOSE_PROJECT_NAME:-morpheus_vuln_analysis}-service-cache
+docker volume rm ${COMPOSE_PROJECT_NAME:-morpheus_vuln_analysis}_service-cache
 ```
 
 #### Vector databases


### PR DESCRIPTION
Fix incorrect `docker volume rm` command in README (change hyphen to underscore).