### PR TITLE
fix: escape backslashes in intel descriptions

### DIFF
--- a/src/cve/nodes/cve_checklist_node.py
+++ b/src/cve/nodes/cve_checklist_node.py
@@ -75,6 +75,9 @@ async def _parse_list(text: list[str]) -> list[list[str]]:
             # Remove newline characters that can cause incorrect string escaping in the next step
             x = x.replace("\n", "")
 
+            # Ensure backslashes are escaped
+            x = x.replace("\\", "\\\\")
+
             # Try to do some very basic string cleanup to fix unescaped quotes
             x = attempt_fix_list_string(x)
 


### PR DESCRIPTION
Description in CVE-2024-5321 was causing a parsing error:

> A flaw was found in Kubernetes clusters with Windows nodes. BUILTIN\Users may be able to read container logs and NT AUTHORITY\Authenticated Users may be able to modify container logs.

The error:
```
raise ValueError(f"Failed to parse input for checklist number {checklist_num}: {x}. Error: {e}")
ValueError: Failed to parse input for checklist number 0: [	"Verify Windows Node Usage: Are there any Windows nodes present in the Kubernetes cluster? The vulnerability specifically affects clusters with Windows nodes, so the presence of such nodes is a prerequisite for exploitability.",	"Assess Container Log Permissions: Review the permissions set on container logs within the cluster. Are the permissions set to allow BUILTIN\Users to read and NT AUTHORITY\Authenticated Users to modify container logs? This is the specific vulnerability being exploited.",	"Evaluate User Group Membership: Identify which users are part of the BUILTIN\Users and NT AUTHORITY\Authenticated Users groups within the cluster. Are there any users who should not have these permissions but are inadvertently included in these groups, potentially increasing the attack surface?"]. Error: (unicode error) 'unicodeescape' codec can't decode bytes in position 139-140: truncated \UXXXXXXXX escape (<unknown>, line 1)
```
