### PR TITLE
Fix openai validation error

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -29,6 +29,7 @@ dependencies:
   # - faiss-gpu=1.7 # Uncomment this when the package supports CUDA 12. See: https://github.com/conda-forge/faiss-split-feedstock/pull/72
   - faiss=1.7
   - gitpython=3.1
+  - httpx>=0.23,<0.28 # work-around for https://github.com/openai/openai-python/issues/1915
   - json5=0.9
   - morpheus-llm=24.10
     # cuda-python=12.6.1 cannot be used because of -


### PR DESCRIPTION
Work-around known openai incompatibility with httpx v0.28 (https://github.com/openai/openai-python/issues/1915)

This fix was copied from this related Morpheus PR: https://github.com/nv-morpheus/Morpheus/pull/2083 for the same issue.