### PR TITLE
Upgrade `langchain` dependencies to 0.3

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -57,10 +57,10 @@ dependencies:
   - pip:
     - google-search-results==2.4
     # Some of the langchain packages are available in conda but cause the solver to fail
-    - langchain==0.2.16
-    - langchain-community==0.2.17
-    - langchain-core==0.2.41
-    - langchain-nvidia-ai-endpoints==0.2.0
+    - langchain>=0.3,<0.4
+    - langchain-community>=0.3,<0.4
+    - langchain-core>=0.3,<0.4
+    - langchain-nvidia-ai-endpoints>=0.3,<0.4
     - nemollm
     - pydpkg==1.9.2
     - rank_bm25==0.2.2

--- a/src/cve/utils/serp_api_wrapper.py
+++ b/src/cve/utils/serp_api_wrapper.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import aiohttp
-from langchain.pydantic_v1 import root_validator
 from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utils.env import get_from_env
+from pydantic import model_validator
 
 from ..utils.async_http_utils import retry_async
 from ..utils.url_utils import url_join
@@ -28,19 +27,15 @@ class MorpheusSerpAPIWrapper(SerpAPIWrapper):
     base_url: str = "https://serpapi.com"
     max_retries: int = 10
 
-    @root_validator()
-    def validate_environment(cls, values: dict) -> dict:
+    @model_validator(mode="after")
+    def validate_base_url(self) -> "MorpheusSerpAPIWrapper":
         """Validate the base URL from the environment."""
-
-        values["base_url"] = get_from_env(key="base_url", env_key="SERPAPI_BASE_URL", default=values["base_url"])
-
-        # Build from the base class
-        values = super().validate_environment(values)
-
+        self.base_url = get_from_env(key="base_url", env_key="SERPAPI_BASE_URL", default=self.base_url)
+        if not self.base_url:
+            raise ValueError("SERPAPI_BASE_URL must not be empty")
         # Update the base URL for search_engine
-        values["search_engine"].BACKEND = values["base_url"]
-
-        return values
+        self.search_engine.BACKEND = self.base_url
+        return self
 
     @retry_async()
     async def _session_get_with_retry(self, session: aiohttp.ClientSession, url: str, params: dict) -> dict:


### PR DESCRIPTION
* Upgrade all `langchain` related dependencies to 0.3 following [recommended version constraints](https://python.langchain.com/docs/versions/v0_3/#how-to-update-your-code).
* This also involved updating `MorpheusSerpAPIWrapper` validator function for compatibility with changes to `SerpAPIWrapper` base class (migrated to pydantic v2, renamed to avoid overriding base class function with different signature).

Current versions should support the latest models such as `nvdev/` and `llama-3.3` models, as well as new features like structured generation.
```
mamba list | grep langchain
  langchain                           0.3.13          pypi_0                             pypi       
  langchain-community                 0.3.13          pypi_0                             pypi       
  langchain-core                      0.3.28          pypi_0                             pypi       
  langchain-nvidia-ai-endpoints       0.3.7           pypi_0                             pypi 
```

Confirmed pipeline works with the latest versions, but haven't run accuracy regression evals.