### PR TITLE
fix: add ES module support to JavaScript parser

### DIFF
--- a/src/cve/utils/document_embedding.py
+++ b/src/cve/utils/document_embedding.py
@@ -38,6 +38,7 @@ from langchain_core.document_loaders.blob_loaders import Blob
 
 from ..data_models.input import SourceDocumentsInfo
 from .source_code_git_loader import SourceCodeGitLoader
+from .js_extended_parser import ExtendedJavaScriptSegmenter
 
 if typing.TYPE_CHECKING:
     from langchain_core.embeddings import Embeddings  # pragma: no cover
@@ -100,8 +101,17 @@ class ExtendedLanguageParser(LanguageParser):
         "hpp": "cpp",
     }
 
+    additional_segmenters: dict[str, type[CodeSegmenter]] = {}
+
+    if os.environ.get('ENABLE_EXTENDED_JS_PARSERS'):
+        additional_segmenters = {
+            "javascript": ExtendedJavaScriptSegmenter,
+            "js": ExtendedJavaScriptSegmenter,
+        }
+
     LANGUAGE_SEGMENTERS: dict[str, type[CodeSegmenter]] = {
         **LANGUAGE_SEGMENTERS,
+        **additional_segmenters,
     }
 
     def lazy_parse(self, blob: Blob) -> typing.Iterator[Document]:

--- a/src/cve/utils/js_extended_parser.py
+++ b/src/cve/utils/js_extended_parser.py
@@ -1,0 +1,86 @@
+import logging
+from typing import List, Any, Tuple
+
+import esprima
+from langchain_community.document_loaders.parsers.language.javascript import JavaScriptSegmenter
+
+logger = logging.getLogger(f"morpheus.{__name__}")
+
+
+class ExtendedJavaScriptSegmenter(JavaScriptSegmenter):
+    """Extended JavaScript segmenter that handles shebang and ES optional chaining."""
+
+    def __init__(self, code: str):
+        """Initialize the segmenter with preprocessed code."""
+        super().__init__(code)
+        # Skip files with shebang (#!) line since they typically contain non-standard JavaScript syntax
+        if code.startswith("#!"):
+            logger.warning("File contains a shebang line. Skipping parsing.")
+            self.skip_file = True
+        # esprima-python parser limitation: cannot handle JavaScript optional chaining syntax,
+        # fallback to regular property access
+        else:
+            self.skip_file = False
+            self.code = self.code.replace("?.", ".")
+
+    def _parse_with_fallback(self) -> Any:
+        """Try to parse code as script first, then as module if that fails."""
+        try:
+            logger.debug("Attempting to parse as a script...")
+            return esprima.parseScript(self.code, loc=True)
+        except esprima.Error:
+            logger.debug("Script parsing failed. Trying module parsing...")
+            try:
+                return esprima.parseModule(self.code, loc=True)
+            except esprima.Error as e:
+                logger.error("Module parsing failed: %s", str(e))
+                return None
+
+    def extract_functions_classes(self) -> List[str]:
+        """Extract functions, classes and exports from the code."""
+        if self.skip_file:
+            return []
+
+        tree = self._parse_with_fallback()
+        if tree is None:
+            return []
+
+        functions_classes = []
+        for node in tree.body:
+            # Handle direct function/class declarations
+            if isinstance(node, (esprima.nodes.FunctionDeclaration, esprima.nodes.ClassDeclaration)):
+                functions_classes.append(self._extract_code(node))
+            # Handle exported declarations
+            elif isinstance(node, esprima.nodes.ExportNamedDeclaration):
+                if isinstance(node.declaration, (esprima.nodes.FunctionDeclaration, esprima.nodes.ClassDeclaration)):
+                    functions_classes.append(self._extract_code(node))
+
+        return functions_classes
+
+    def simplify_code(self) -> str:
+        """Simplify the code by replacing function/class bodies with comments."""
+        if self.skip_file:
+            return self.code
+
+        tree = self._parse_with_fallback()
+        if tree is None:
+            return self.code
+
+        simplified_lines = self.source_lines[:]
+        indices_to_del: List[Tuple[int, int]] = []
+
+        for node in tree.body:
+            if isinstance(node, (esprima.nodes.FunctionDeclaration, esprima.nodes.ClassDeclaration)):
+                start, end = node.loc.start.line - 1, node.loc.end.line
+                simplified_lines[start] = f"// Code for: {simplified_lines[start]}"
+                indices_to_del.append((start + 1, end))
+            elif isinstance(node, esprima.nodes.ExportNamedDeclaration):
+                if isinstance(node.declaration, (esprima.nodes.FunctionDeclaration, esprima.nodes.ClassDeclaration)):
+                    start, end = node.loc.start.line - 1, node.loc.end.line
+                    simplified_lines[start] = f"// Code for: {simplified_lines[start]}"
+                    indices_to_del.append((start + 1, end))
+
+        for start, end in reversed(indices_to_del):
+            del simplified_lines[start:end]
+
+        return "\n".join(line for line in simplified_lines)

--- a/src/cve/utils/tests/test_java_script_extended.py
+++ b/src/cve/utils/tests/test_java_script_extended.py
@@ -1,0 +1,113 @@
+import pytest
+
+from ..js_extended_parser import ExtendedJavaScriptSegmenter
+
+TEST_CASES = [
+    {
+        "name": "regular_script",
+        "code": """
+function hello() {
+    console.log('Hello');
+}
+
+class MyClass {
+    constructor() {
+        this.value = 42;
+    }
+}
+""",
+        "expected_functions": 2,  # One function and one class
+        "should_parse": True,
+    },
+    {
+        "name": "es_module",
+        "code": """
+import { something } from './module';
+export function exportedFunc() {
+    return 'exported';
+}
+export class ExportedClass {
+    method() {}
+}
+""",
+        "expected_functions": 2,  # One exported function and one exported class
+        "should_parse": True,
+    },
+    {
+        "name": "optional_chaining",
+        "code": """
+function processUser(user) {
+    return user?.profile?.name;
+}
+class UserManager {
+    getAddress() {
+        return this.user?.address?.street;
+    }
+}
+""",
+        "expected_functions": 2,
+        "should_parse": True,
+    },
+    {
+        "name": "shebang_file",
+        "code": """#!/usr/bin/env node
+function main() {
+    console.log('Main');
+}
+""",
+        "expected_functions": 0,  # Should skip due to shebang
+        "should_parse": False,
+    }
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES, ids=lambda x: x["name"])
+def test_function_extraction(test_case):
+    """Test that functions and classes are correctly extracted."""
+    segmenter = ExtendedJavaScriptSegmenter(test_case["code"])
+    functions = segmenter.extract_functions_classes()
+    assert len(functions) == test_case["expected_functions"]
+    if not test_case["should_parse"]:
+        assert segmenter.skip_file
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES, ids=lambda x: x["name"])
+def test_code_simplification(test_case):
+    """Test that code is correctly simplified."""
+    segmenter = ExtendedJavaScriptSegmenter(test_case["code"])
+    simplified = segmenter.simplify_code()
+
+    # Basic checks
+    assert isinstance(simplified, str)
+    if not test_case["should_parse"]:
+        assert segmenter.skip_file
+        assert simplified == test_case["code"]  # Return original code for unparseable files
+    else:
+        # Should have fewer or equal lines than original
+        assert len(simplified.splitlines()) <= len(test_case["code"].splitlines())
+        # Should contain "// Code for:" for each function/class
+        if test_case["expected_functions"] > 0:
+            assert "// Code for:" in simplified
+
+
+def test_optional_chaining_replacement():
+    """Test that optional chaining is correctly replaced."""
+    code = "const name = user?.profile?.name;"
+    segmenter = ExtendedJavaScriptSegmenter(code)
+    assert not segmenter.skip_file
+    assert "?." not in segmenter.code
+    assert "." in segmenter.code
+
+
+def test_invalid_js():
+    """Test handling of invalid JavaScript code."""
+    code = "this is not valid javascript"
+    segmenter = ExtendedJavaScriptSegmenter(code)
+    assert not segmenter.skip_file  # Should attempt to parse
+
+    # Should handle errors gracefully
+    functions = segmenter.extract_functions_classes()
+    assert functions == []
+
+    simplified = segmenter.simplify_code()
+    assert simplified == code  # Return original code for invalid JS


### PR DESCRIPTION
Closes #47 

In our fix, we used an additional environment variable `ENABLE_EXTENDED_JS_PARSERS` to enable/disable the extended JS parser.

If it is not needed, I will remove it.