### PR TITLE
Write newline after each scan result in `write_pydantic_to_file`

### DIFF
--- a/src/cve/stages/write_pydantic_to_file.py
+++ b/src/cve/stages/write_pydantic_to_file.py
@@ -109,6 +109,7 @@ class WritePydanticToFile(PassThruTypeMixin, SinglePortStage):
 
         with open(file_path, 'a') as f:
             f.write(model_json)
+            f.write("\n")
 
         # Make stage a pass-through
         return model


### PR DESCRIPTION
When using `model_log_file` option in run config, each scan result is being appended to same line. You therefore cannot read file using something like this:
```
df = pd.read_json("output_model_nspect_http.json", lines=True)

ValueError: Unexpected character found when decoding array value (2)
```
This PR updates `write_pydantic_to_file` to add new line (\n) after each scan result.