### PR TITLE
Add health check endpoints to http server

### DIFF
--- a/src/cve/stages/pydantic_http_stage.py
+++ b/src/cve/stages/pydantic_http_stage.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/cve/stages/pydantic_http_stage.py
+++ b/src/cve/stages/pydantic_http_stage.py
@@ -1,11 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,18 +25,19 @@ import mrc
 from pydantic import BaseModel
 
 from morpheus.common import FiberQueue
-from morpheus.common import HttpEndpoint
 from morpheus.config import Config
 from morpheus.pipeline.preallocator_mixin import PreallocatorMixin
 from morpheus.pipeline.single_output_source import SingleOutputSource
 from morpheus.pipeline.stage_schema import StageSchema
-from morpheus.stages.input.http_server_source_stage import SUPPORTED_METHODS
 from morpheus.utils.http_utils import HTTPMethod
 from morpheus.utils.http_utils import HttpParseResponse
 from morpheus.utils.http_utils import MimeTypes
 from morpheus.utils.producer_consumer_queue import Closed
 
-logger = logging.getLogger(f"morpheus.{__name__}")
+logger = logging.getLogger(__name__)
+
+SUPPORTED_METHODS = (HTTPMethod.POST, HTTPMethod.PUT)
+HEALTH_SUPPORTED_METHODS = (HTTPMethod.GET, HTTPMethod.POST)
 
 
 class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
@@ -75,7 +75,7 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
         If False, the HTTP server will expect each request to be a JSON array of objects. If True, the HTTP server will
         expect each request to be a JSON object per line.
     stop_after : int, default 0
-        Stops ingesting after processing `stop_after` requests. Useful for testing. Disabled if `0`
+        Stops ingesting after emitting `stop_after` records (rows in the dataframe). Useful for testing. Disabled if `0`
     payload_to_df_fn : callable, default None
         A callable that takes the HTTP payload string as the first argument and the `lines` parameter is passed in as
         the second argument and returns a cudf.DataFrame. When supplied, the C++ implementation of this stage is
@@ -88,7 +88,11 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
                  bind_address: str = "127.0.0.1",
                  port: int = 8080,
                  endpoint: str = "/message",
+                 live_endpoint: str = "/live",
+                 ready_endpoint: str = "/ready",
                  method: HTTPMethod = HTTPMethod.POST,
+                 live_method: HTTPMethod = HTTPMethod.GET,
+                 ready_method: HTTPMethod = HTTPMethod.GET,
                  accept_status: HTTPStatus = HTTPStatus.CREATED,
                  sleep_time: float = 0.1,
                  queue_timeout: int = 5,
@@ -103,7 +107,11 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
         self._bind_address = bind_address
         self._port = port
         self._endpoint = endpoint
+        self._live_endpoint = live_endpoint
+        self._ready_endpoint = ready_endpoint
         self._method = method
+        self._live_method = live_method
+        self._ready_method = ready_method
         self._accept_status = accept_status
         self._sleep_time = sleep_time
         self._queue_timeout = queue_timeout
@@ -116,13 +124,14 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
 
         # These are only used when C++ mode is disabled
         self._queue: FiberQueue = None
+        self._queue_size = 0
         self._processing = False
         self._messages_processed = 0
         self._input_schema = input_schema
         self._http_server = None
 
-        if method not in SUPPORTED_METHODS:
-            raise ValueError(f"Unsupported method: {method}")
+        for url, http_method in [(endpoint, method), (live_endpoint, live_method), (ready_endpoint, ready_method)]:
+            check_supported_method(url, http_method, SUPPORTED_METHODS if url == endpoint else HEALTH_SUPPORTED_METHODS)
 
         if accept_status.value < 200 or accept_status.value > 299:
             raise ValueError(f"Invalid accept_status: {accept_status}")
@@ -166,6 +175,7 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
 
         try:
             self._queue.put(message, block=True, timeout=self._queue_timeout)
+            self._queue_size += 1
             return HttpParseResponse(status_code=self._accept_status.value, content_type=MimeTypes.TEXT.value, body="")
 
         except (queue.Full, Closed) as e:
@@ -186,15 +196,45 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
                                      content_type=MimeTypes.TEXT.value,
                                      body=err_msg)
 
+    def _liveliness_check(self, _: str) -> HttpParseResponse:
+        if not self._http_server.is_running():
+            err_msg = "Source server is not running"
+            logger.error(err_msg)
+            return HttpParseResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+                                     content_type=MimeTypes.TEXT.value,
+                                     body=err_msg)
+
+        return HttpParseResponse(status_code=HTTPStatus.OK.value, content_type=MimeTypes.TEXT.value, body="")
+
+    def _readiness_check(self, _: str) -> HttpParseResponse:
+        if not self._http_server.is_running():
+            err_msg = "Source server is not running"
+            logger.error(err_msg)
+            return HttpParseResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                                     content_type=MimeTypes.TEXT.value,
+                                     body=err_msg)
+
+        if self._queue_size < self._max_queue_size:
+            return HttpParseResponse(status_code=HTTPStatus.OK.value, content_type=MimeTypes.TEXT.value, body="")
+
+        err_msg = "HTTP payload queue is full or unavailable to accept new values"
+        logger.error(err_msg)
+        return HttpParseResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+                                 content_type=MimeTypes.TEXT.value,
+                                 body=err_msg)
+
     def _generate_frames(self, subscription: mrc.Subscription) -> typing.Iterator[BaseModel]:
         from morpheus.common import FiberQueue
+        from morpheus.common import HttpEndpoint
         from morpheus.common import HttpServer
 
-        endpoints = [HttpEndpoint(py_parse_fn=self._parse_payload, url=self._endpoint, method=self._method.value)]
+        msg = HttpEndpoint(self._parse_payload, self._endpoint, self._method.name)
+        live = HttpEndpoint(self._liveliness_check, self._live_endpoint, self._live_method.name)
+        ready = HttpEndpoint(self._readiness_check, self._ready_endpoint, self._ready_method.name)
         with (FiberQueue(self._max_queue_size) as self._queue,
-              HttpServer(bind_address=self._bind_address,
+              HttpServer(endpoints=[msg, live, ready],
+                         bind_address=self._bind_address,
                          port=self._port,
-                         endpoints=endpoints,
                          num_threads=self._num_server_threads,
                          max_payload_size=self._max_payload_size_bytes,
                          request_timeout=self._request_timeout_secs) as self._http_server):
@@ -208,6 +248,7 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
                 try:
                     # Intentionally not using self._queue_timeout here since that value is rather high
                     message = self._queue.get(block=False, timeout=0.1)
+                    self._queue_size -= 1
                 except queue.Empty:
                     if (not self._http_server.is_running() or self.is_stop_requested()
                             or not subscription.is_subscribed()):
@@ -231,3 +272,9 @@ class PydanticHttpStage(PreallocatorMixin, SingleOutputSource):
         node = builder.make_source(self.unique_name, self._generate_frames)
 
         return node
+
+
+def check_supported_method(endpoint: str, method: HTTPMethod, supported_methods: typing.Tuple[HTTPMethod, ...]) -> None:
+    if method not in supported_methods:
+        raise ValueError(
+            f"Unsupported method {method} for endpoint {endpoint}. Supported methods are {supported_methods}")

--- a/src/cve/stages/pydantic_http_stage.py
+++ b/src/cve/stages/pydantic_http_stage.py
@@ -35,7 +35,7 @@ from morpheus.utils.http_utils import HttpParseResponse
 from morpheus.utils.http_utils import MimeTypes
 from morpheus.utils.producer_consumer_queue import Closed
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"morpheus.{__name__}")
 
 SUPPORTED_METHODS = (HTTPMethod.POST, HTTPMethod.PUT)
 HEALTH_SUPPORTED_METHODS = (HTTPMethod.GET, HTTPMethod.POST)


### PR DESCRIPTION
Adds `/live` and `/ready` health check endpoints which return HTTP status 200 if everything is okay.

Note: relevant code copied from Morpheus [HttpServerSourceStage](https://github.com/nv-morpheus/Morpheus/blob/branch-25.02/python/morpheus/morpheus/stages/input/http_server_source_stage.py).