### PR TITLE
Fix pipeline crash when there are no documents for embedding

### DIFF
--- a/src/cve/utils/document_embedding.py
+++ b/src/cve/utils/document_embedding.py
@@ -387,6 +387,11 @@ class DocumentEmbedding:
         for input_dir in source_infos:
             documents.extend(self.collect_documents(input_dir))
 
+        # Warn and return early if no documents were collected
+        if len(documents) == 0:
+            logger.warning("No documents were collected, skipping VDB generation for source infos: %s", source_infos)
+            return None
+
         # Apply chunking on the source documents
         chunked_documents = self._chunk_documents(documents)
 


### PR DESCRIPTION
Resolves #55 

Confirmed the pipeline logs the following warning and finishes successfully:
```
No documents were collected, skipping VDB generation for source infos: [SourceDocumentsInfo(type='code', git_repo='https://github.com/openshift/ironic-image', ref='eb583102cfbf9a41a8ef9fc5b8d8b580aae9be90', include=['**/*.py', 'pyproject.toml', 'setup.cfg', 'setup.py'], exclude=['*.pyc', '*.pyd', '*.pyo', '.mypy_cache/**/*', '.pytest_cache/**/*', '.venv/**/*', 'Pipfile', 'Pipfile.lock', '__pycache__/**/*', 'build/**/*', 'dist/**/*', 'env/**/*', 'requirements.txt', 'test/**/*', 'tests/**/*', 'venv/**/*'])]
```