### PR TITLE
Add utility function to get Git repo from path

### DIFF
--- a/src/cve/stages/build_vdb_stage.py
+++ b/src/cve/stages/build_vdb_stage.py
@@ -29,7 +29,7 @@ from ..data_models.info import AgentMorpheusInfo
 from ..data_models.input import AgentMorpheusEngineInput
 from ..data_models.input import AgentMorpheusInput
 from ..data_models.input import SourceDocumentsInfo
-from ..utils.git_utils import get_commit_hash
+from ..utils.git_utils import get_repo_from_path
 
 logger = logging.getLogger(f"morpheus.{__name__}")
 
@@ -117,8 +117,8 @@ class BuildSourceCodeVdbStage(SinglePortStage):
                 vdb_doc_path = str(vdb_doc_path)
 
             for si in source_infos:
-                si.ref = get_commit_hash(self._base_git_dir,
-                                            si.git_repo)
+                repo = get_repo_from_path(self._base_git_dir, si.git_repo)
+                si.ref = repo.commit().hexsha
 
         except Exception as e:
             # For now just skip the row

--- a/src/cve/utils/git_utils.py
+++ b/src/cve/utils/git_utils.py
@@ -21,9 +21,9 @@ from pathlib import PurePath
 from git import Repo
 
 
-def get_commit_hash(base_dir: str, git_repo: str = ".git") -> str | None:
+def get_repo_from_path(base_dir: str, git_repo: str = ".git") -> Repo:
     """
-    Utility function for getting commit hash of Git repo.
+    Utility function for getting GitPython `Repo` object representing a Git repository.
 
     Parameters
     ----------
@@ -34,14 +34,20 @@ def get_commit_hash(base_dir: str, git_repo: str = ".git") -> str | None:
 
     Returns
     -------
-    str
-        Commit hash of Git repo
+    repo
+        GitPython `Repo` object representing the Git repository.
+
+    Raises
+    ------
+    ValueError
+        If the repository path does not exist.
     """
-    commit_hash: str | None = None
     repo_path = base_dir / PurePath(git_repo)
     repo_path = Path(repo_path)
     if os.path.exists(repo_path):
-        repo = Repo(repo_path)
-        commit_hash = repo.commit().hexsha
-
-    return commit_hash
+        try:
+            return Repo(repo_path)
+        except Exception as e:
+            raise ValueError(f"Invalid Git repository: {repo_path}") from e
+    else:
+        raise ValueError(f"Path {repo_path} does not exist")


### PR DESCRIPTION
- Add utility function `get_repo_from_path` to get `GitPython` repo object from a path
- Replaces `get_commit_hash` to give more flexibility
- Update `build_vdb_stage` to use `get_repo_from_path` instead of `get_commit_hash`
- Tried using `load_repo` in `SourceCodeGitLoader` but that throws error when working repos with uncommitted changes because it performs checkout of a ref before returning the repo.