### PR TITLE
Handle invalid Git repo errors

### DIFF
--- a/src/cve/stages/build_vdb_stage.py
+++ b/src/cve/stages/build_vdb_stage.py
@@ -117,9 +117,13 @@ class BuildSourceCodeVdbStage(SinglePortStage):
                 vdb_doc_path = str(vdb_doc_path)
 
             for si in source_infos:
-                repo = get_repo_from_path(self._base_git_dir, si.git_repo)
-                si.ref = repo.commit().hexsha
-
+                try:
+                    repo = get_repo_from_path(self._base_git_dir, si.git_repo)
+                    si.ref = repo.commit().hexsha
+                except ValueError as e:
+                    logger.warning("Failed to get commit hash for %s/%s: %s", self._base_git_dir, si.git_repo, e)
+                    continue
+                
         except Exception as e:
             # For now just skip the row
             logger.error("Failure to build VDB for image, '%s', with source code info: %s\nError: %s",

--- a/src/cve/utils/document_embedding.py
+++ b/src/cve/utils/document_embedding.py
@@ -385,7 +385,12 @@ class DocumentEmbedding:
 
         documents = []
         for input_dir in source_infos:
-            documents.extend(self.collect_documents(input_dir))
+            try:
+                documents.extend(self.collect_documents(input_dir))
+            except Exception as e:
+                logger.warning("Error collecting documents for source info %s: %s", input_dir, e)
+                continue
+
 
         # Warn and return early if no documents were collected
         if len(documents) == 0:


### PR DESCRIPTION
1. Handle errors from invalid Git repo urls in source_info. Catches error, logs it, and moves on to next source_info.
2. Prevents these errors from crashing pipeline.