### PR TITLE
Change `VulnerableDependencyChecker` justification label to `false_positive`

### DIFF
--- a/src/cve/stages/convert_to_output_object.py
+++ b/src/cve/stages/convert_to_output_object.py
@@ -81,7 +81,7 @@ def _parse_agent_morpheus_engine_output(row: dict) -> AgentMorpheusEngineOutput:
 
 def _get_no_vuln_packages_output(vuln_id: str) -> AgentMorpheusEngineOutput:
     SUMMARY = "The VulnerableDependencyChecker did not find any vulnerable packages or dependencies in the SBOM."
-    JUSTIFICATION = JustificationOutput(label="code_not_present",
+    JUSTIFICATION = JustificationOutput(label="false_positive",
                                         reason="No vulnerable packages or dependencies were detected in the SBOM.",
                                         status="FALSE")
     return AgentMorpheusEngineOutput(


### PR DESCRIPTION
Closes #64.

Change the default justification label for vulns filtered by the `VulnerableDependencyChecker` from `code_not_present` to `false_positive`.

The introduction of a new label aligns better with the `false_positive` label introduced in the [README](https://github.com/NVIDIA-AI-Blueprints/vulnerability-analysis/blob/main/README.md?plain=1#L162), and also with the `component_not_present` label in [CISA's VEX definitions](https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf).