### PR TITLE
Fix executing into directory error in 1_Deploy_CVE.ipynb

### DIFF
--- a/deploy/1_Deploy_CVE.ipynb
+++ b/deploy/1_Deploy_CVE.ipynb
@@ -842,7 +842,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%cd vulnerability-analysis/"
+    "%cd ~/vulnerability-analysis/"
    ]
   },
   {


### PR DESCRIPTION
In the deploy CVE notebook, Line 843, when user executes into the directory an error occurs that saying no file or directory found due to missing this `~`.

Solution is to add `~ ` to the directory path: `%cd ~/vulnerability-analysis/`.  User can also remove that line since the root directory has been set already with `REPO_ROOT`.

Example error:
```

"%cd vulnerability-analysis/", occurred (all the previous steps and env have been set) :
[Errno 2] No such file or directory: 'vulnerability-analysis/'
/home/ubuntu/vulnerability-analysis
```