### PR TITLE
Add max_retries option to cve_fetch_intel

### DIFF
--- a/src/vuln_analysis/functions/cve_fetch_intel.py
+++ b/src/vuln_analysis/functions/cve_fetch_intel.py
@@ -31,7 +31,8 @@ class CVEFetchIntelConfig(FunctionBaseConfig, name="cve_fetch_intel"):
     """
     Defines a function that fetches details about CVEs from NIST and CVE Details websites.
     """
-    retry_on_client_errors: bool = Field(default=True, description="Whether to retry if HTTP client cannot connect")
+    max_retries: int = Field(default=10, description="Maximum number of retries on client and server errors")
+    retry_on_client_errors: bool = Field(default=True, description="Whether to retry on client errors")
 
 
 @register_function(config_type=CVEFetchIntelConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
@@ -46,7 +47,9 @@ async def cve_fetch_intel(config: CVEFetchIntelConfig, builder: Builder):  # pyl
 
             async with aiohttp.ClientSession() as session:
 
-                intel_retriever = IntelRetriever(session=session, retry_on_client_errors=config.retry_on_client_errors)
+                intel_retriever = IntelRetriever(session=session,
+                                                 max_retries=config.max_retries,
+                                                 retry_on_client_errors=config.retry_on_client_errors)
 
                 intel_coros = [intel_retriever.retrieve(vuln_id=cve.vuln_id) for cve in message.input.scan.vulns]
 


### PR DESCRIPTION
Add `max_retries` config option to `cve_fetch_intel` to configure maximum number of retries on intel clients. This can be used to reduce latency when encountering server errors from intel sources.