### PR TITLE
Add client_timeout option to cve_fetch_intel

### DIFF
--- a/src/vuln_analysis/functions/cve_fetch_intel.py
+++ b/src/vuln_analysis/functions/cve_fetch_intel.py
@@ -31,6 +31,7 @@ class CVEFetchIntelConfig(FunctionBaseConfig, name="cve_fetch_intel"):
     """
     Defines a function that fetches details about CVEs from NIST and CVE Details websites.
     """
+    client_timeout: int = Field(default=300, description="Client request timeout in seconds")
     max_retries: int = Field(default=10, description="Maximum number of retries on client and server errors")
     retry_on_client_errors: bool = Field(default=True, description="Whether to retry on client errors")
 
@@ -45,7 +46,8 @@ async def cve_fetch_intel(config: CVEFetchIntelConfig, builder: Builder):  # pyl
 
         async def _inner():
 
-            async with aiohttp.ClientSession() as session:
+            timeout = aiohttp.ClientTimeout(total=config.client_timeout)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
 
                 intel_retriever = IntelRetriever(session=session,
                                                  max_retries=config.max_retries,


### PR DESCRIPTION
Add option set client request timeout for intel clients. For example,
```
cve_fetch_intel:
  _type: cve_fetch_intel
  client_timeout: 10
```
This sets timeout to 10 seconds.